### PR TITLE
Add auth flags

### DIFF
--- a/cmd/auth.go
+++ b/cmd/auth.go
@@ -7,6 +7,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var SITENAME string
+
 // ----------------------------------------------
 // auth command
 // ----------------------------------------------
@@ -25,17 +27,10 @@ var authCmd = &cobra.Command{
 // ----------------------------------------------
 
 func auth() {
-	fmt.Println("Enter sitename:")
-	var sitename string
-	_, err := fmt.Scan(&sitename)
-	if err != nil {
-		fmt.Println(err)
-		os.Exit(1)
-	}
-
 	fmt.Println("Enter username:")
 	var username string
-	_, err = fmt.Scan(&username)
+	_, err := fmt.Scan(&username)
+	// _, err = fmt.Scan(&username)
 	if err != nil {
 		fmt.Println(err)
 		os.Exit(1)
@@ -50,7 +45,7 @@ func auth() {
 	}
 
 	// Call the authenticate function to get the access token and expires in
-	response, err := authenticate(sitename, username, password)
+	response, err := authenticate(SITENAME, username, password)
 	if err != nil {
 		fmt.Println("Error authenticating:", err)
 		os.Exit(1)
@@ -69,4 +64,6 @@ func auth() {
 
 func init() {
 	rootCmd.AddCommand(authCmd)
+	authCmd.Flags().StringVarP(&SITENAME, "sitename", "s", "", "EarthRanger site name")
+	authCmd.MarkFlagRequired("sitename")
 }

--- a/cmd/auth.go
+++ b/cmd/auth.go
@@ -7,7 +7,12 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// ----------------------------------------------
+// static var
+// ----------------------------------------------
+
 var SITENAME string
+var USERNAME string
 
 // ----------------------------------------------
 // auth command
@@ -27,25 +32,16 @@ var authCmd = &cobra.Command{
 // ----------------------------------------------
 
 func auth() {
-	fmt.Println("Enter username:")
-	var username string
-	_, err := fmt.Scan(&username)
-	// _, err = fmt.Scan(&username)
-	if err != nil {
-		fmt.Println(err)
-		os.Exit(1)
-	}
-
 	fmt.Println("Enter password:")
 	var password string
-	_, err = fmt.Scan(&password)
+	_, err := fmt.Scan(&password)
 	if err != nil {
 		fmt.Println(err)
 		os.Exit(1)
 	}
 
 	// Call the authenticate function to get the access token and expires in
-	response, err := authenticate(SITENAME, username, password)
+	response, err := authenticate(SITENAME, USERNAME, password)
 	if err != nil {
 		fmt.Println("Error authenticating:", err)
 		os.Exit(1)
@@ -65,5 +61,7 @@ func auth() {
 func init() {
 	rootCmd.AddCommand(authCmd)
 	authCmd.Flags().StringVarP(&SITENAME, "sitename", "s", "", "EarthRanger site name")
+	authCmd.Flags().StringVarP(&USERNAME, "username", "u", "", "EarthRanger user name")
 	authCmd.MarkFlagRequired("sitename")
+	authCmd.MarkFlagRequired("username")
 }

--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,9 @@ module github.com/doneill/er-cli-go
 
 go 1.21.4
 
+require github.com/spf13/cobra v1.8.0
+
 require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
-	github.com/spf13/cobra v1.8.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 )


### PR DESCRIPTION
Add `sitename` and `username` required flags to `auth` command

**Manual Test**
- Build app
- Authenticate with flags
  - `./er auth --sitename={sitename} --username={username}`
- Authenticate with shortcut flags
  - `./er auth -s={sitename} -u={username}`
- Confirm token and expiry returned