### PR TITLE
Refactor users add initial tests

### DIFF
--- a/api/apiuser.go
+++ b/api/apiuser.go
@@ -3,8 +3,6 @@ package api
 import (
 	"fmt"
 	"path"
-
-	"github.com/doneill/er-cli/config"
 )
 
 // ----------------------------------------------
@@ -44,38 +42,32 @@ type UserResponse struct {
 }
 
 // ----------------------------------------------
-// exported funtions
+// client functions
 // ----------------------------------------------
-
-func User() (*UserResponse, error) {
-	client := ERClient(config.Sitename(), config.Token())
-
-	req, err := client.newRequest("GET", API_USER_ME, false)
+func (c *Client) User() (*UserResponse, error) {
+	req, err := c.newRequest("GET", API_USER_ME, false)
 	if err != nil {
 		return nil, fmt.Errorf("error generating request: %w", err)
 	}
 
 	var responseData UserResponse
-	if err := client.doRequest(req, &responseData); err != nil {
+	if err := c.doRequest(req, &responseData); err != nil {
 		return nil, fmt.Errorf("error making request: %w", err)
 	}
 
 	return &responseData, nil
 }
 
-func UserProfiles(userID string) (*UserProfilesResponse, error) {
-	client := ERClient(config.Sitename(), config.Token())
-
-	// Construct the profiles endpoint
+func (c *Client) UserProfiles(userID string) (*UserProfilesResponse, error) {
 	profilesEndpoint := path.Join(API_USER, userID, API_USER_PROFILES)
 
-	req, err := client.newRequest("GET", profilesEndpoint, false)
+	req, err := c.newRequest("GET", profilesEndpoint, false)
 	if err != nil {
 		return nil, fmt.Errorf("error generating profiles request: %w", err)
 	}
 
 	var responseData UserProfilesResponse
-	if err := client.doRequest(req, &responseData); err != nil {
+	if err := c.doRequest(req, &responseData); err != nil {
 		return nil, fmt.Errorf("error fetching profiles: %w", err)
 	}
 

--- a/api/ersvc.go
+++ b/api/ersvc.go
@@ -23,31 +23,37 @@ const API_USER_ME = API_USER + "/me"
 const API_USER_PROFILES = "/profiles"
 
 // ----------------------------------------------
-// Struct
+// struct
 // ----------------------------------------------
 
 type Client struct {
 	httpClient *http.Client
 	sitename   string
 	token      string
+	mockURL    string
 }
 
 // ----------------------------------------------
-// Functions
+// functions
 // ----------------------------------------------
 
-func ERClient(sitename, token string) *Client {
+func ERClient(sitename, token string, opts ...string) *Client {
+	mockURL := ""
+	if len(opts) > 0 {
+		mockURL = opts[0]
+	}
 	return &Client{
 		httpClient: &http.Client{
 			Timeout: 10 * time.Second,
 		},
 		sitename: sitename,
 		token:    token,
+		mockURL:  mockURL,
 	}
 }
 
 func (c *Client) newRequest(method, endpoint string, isAuth bool) (*http.Request, error) {
-	url := getApiUrl(c.sitename, endpoint)
+	url := getApiUrl(c.sitename, endpoint, c.mockURL)
 	req, err := http.NewRequest(method, url, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request: %w", err)
@@ -88,16 +94,13 @@ func (c *Client) doRequest(req *http.Request, v interface{}) error {
 // Helper functions
 // ----------------------------------------------
 
-func getApiUrl(sitename string, endpoint string) string {
+func getApiUrl(sitename string, endpoint string, mockURL string) string {
+	if mockURL != "" {
+		return mockURL + endpoint
+	}
 	return fmt.Sprintf("https://%s%s%s", sitename, DOMAIN, endpoint)
 }
 
-func getAuthRequest(sitename string) (*http.Request, error) {
-	client := ERClient(sitename, "")
-	return client.newRequest("POST", API_AUTH, true)
-}
-
-func getClientRequest(sitename string, endpoint string, token string) (*http.Request, error) {
-	client := ERClient(sitename, token)
-	return client.newRequest("GET", endpoint, false)
+func getMockApiUrl(mocksite string, endpoint string) string {
+	return mocksite + endpoint
 }

--- a/api/user_test.go
+++ b/api/user_test.go
@@ -1,0 +1,183 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path"
+	"strings"
+	"testing"
+)
+
+func TestUser(t *testing.T) {
+	tests := []struct {
+		name           string
+		serverResponse *UserResponse
+		statusCode     int
+		expectError    bool
+	}{
+		{
+			name: "successful response",
+			serverResponse: &UserResponse{
+				Data: UserData{
+					Username:  "testuser",
+					Email:     "test@example.com",
+					FirstName: "Test",
+					LastName:  "User",
+					ID:        "123",
+					Subject: struct {
+						ID string `json:"id"`
+					}{ID: "456"},
+				},
+			},
+			statusCode:  http.StatusOK,
+			expectError: false,
+		},
+		{
+			name:           "server error",
+			serverResponse: nil,
+			statusCode:     http.StatusInternalServerError,
+			expectError:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Method != http.MethodGet {
+					t.Errorf("expected GET request, got %s", r.Method)
+				}
+				if r.Header.Get("Authorization") != "Bearer testtoken" {
+					t.Errorf("expected Bearer testtoken, got %s", r.Header.Get("Authorization"))
+				}
+
+				w.WriteHeader(tt.statusCode)
+				if tt.serverResponse != nil {
+					if err := json.NewEncoder(w).Encode(tt.serverResponse); err != nil {
+						t.Errorf("failed to encode response: %v", err)
+						return
+					}
+				}
+			}))
+			defer server.Close()
+
+			er := ERClient("test", "testtoken", server.URL)
+			resp, err := er.User()
+
+			if tt.expectError && err == nil {
+				t.Error("expected error, got nil")
+			}
+			if !tt.expectError && err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+
+			if !tt.expectError {
+				if resp == nil {
+					t.Fatal("expected response, got nil")
+				}
+				if resp.Data.Username != tt.serverResponse.Data.Username {
+					t.Errorf("expected username %s, got %s",
+						tt.serverResponse.Data.Username, resp.Data.Username)
+				}
+			}
+		})
+	}
+}
+
+func TestUserProfiles(t *testing.T) {
+	tests := []struct {
+		name           string
+		userID         string
+		serverResponse *UserProfilesResponse
+		statusCode     int
+		expectError    bool
+	}{
+		{
+			name:   "successful response",
+			userID: "123",
+			serverResponse: &UserProfilesResponse{
+				Data: []UserData{
+					{
+						Username:  "profile1",
+						Email:     "profile1@example.com",
+						FirstName: "Profile",
+						LastName:  "One",
+						ID:        "456",
+						Subject: struct {
+							ID string `json:"id"`
+						}{ID: "789"},
+					},
+				},
+			},
+			statusCode:  http.StatusOK,
+			expectError: false,
+		},
+		{
+			name:           "server error",
+			userID:         "123",
+			serverResponse: nil,
+			statusCode:     http.StatusInternalServerError,
+			expectError:    true,
+		},
+		{
+			name:           "invalid user ID",
+			userID:         "",
+			serverResponse: nil,
+			statusCode:     http.StatusBadRequest,
+			expectError:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Method != http.MethodGet {
+					t.Errorf("expected GET request, got %s", r.Method)
+				}
+				if r.Header.Get("Authorization") != "Bearer testtoken" {
+					t.Errorf("expected Bearer testtoken, got %s", r.Header.Get("Authorization"))
+				}
+
+				expectedPath := path.Join(API_USER, tt.userID, API_USER_PROFILES)
+				if !strings.HasSuffix(r.URL.Path, expectedPath) {
+					t.Errorf("expected path to end with %s, got %s", expectedPath, r.URL.Path)
+				}
+
+				w.WriteHeader(tt.statusCode)
+				if tt.serverResponse != nil {
+					if err := json.NewEncoder(w).Encode(tt.serverResponse); err != nil {
+						t.Errorf("failed to encode response: %v", err)
+						return
+					}
+				}
+			}))
+			defer server.Close()
+
+			er := ERClient("test", "testtoken", server.URL)
+			resp, err := er.UserProfiles(tt.userID)
+
+			if tt.expectError && err == nil {
+				t.Error("expected error, got nil")
+			}
+			if !tt.expectError && err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+
+			if !tt.expectError {
+				if resp == nil {
+					t.Fatal("expected response, got nil")
+				}
+				if len(resp.Data) != len(tt.serverResponse.Data) {
+					t.Errorf("expected %d profiles, got %d",
+						len(tt.serverResponse.Data), len(resp.Data))
+				}
+				if len(resp.Data) > 0 {
+					if resp.Data[0].Username != tt.serverResponse.Data[0].Username {
+						t.Errorf("expected username %s, got %s",
+							tt.serverResponse.Data[0].Username, resp.Data[0].Username)
+					}
+				}
+			}
+		})
+	}
+}

--- a/cmd/user.go
+++ b/cmd/user.go
@@ -6,6 +6,7 @@ import (
 	"os"
 
 	"github.com/doneill/er-cli/api"
+	"github.com/doneill/er-cli/config"
 	"github.com/olekukonko/tablewriter"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -34,7 +35,8 @@ var userCmd = &cobra.Command{
 // ----------------------------------------------
 
 func user() {
-	userResponse, err := api.User()
+	er := api.ERClient(config.Sitename(), config.Token())
+	userResponse, err := er.User()
 	if err != nil {
 		log.Fatalf("Error authentication: %v", err)
 	}
@@ -59,7 +61,8 @@ func user() {
 }
 
 func handleProfiles(userID string) {
-	profilesResponse, err := api.UserProfiles(userID)
+	er := api.ERClient(config.Sitename(), config.Token())
+	profilesResponse, err := er.UserProfiles(userID)
 	if err != nil {
 		log.Fatalf("Error getting profiles: %v", err)
 	}


### PR DESCRIPTION
Refactored User API to reuseable client functions
Add initial user tests

```
go test ./... -v
=== RUN   TestUser
=== RUN   TestUser/successful_response
=== RUN   TestUser/server_error
--- PASS: TestUser (0.00s)
    --- PASS: TestUser/successful_response (0.00s)
    --- PASS: TestUser/server_error (0.00s)
=== RUN   TestUserProfiles
=== RUN   TestUserProfiles/successful_response
=== RUN   TestUserProfiles/server_error
=== RUN   TestUserProfiles/invalid_user_ID
--- PASS: TestUserProfiles (0.00s)
    --- PASS: TestUserProfiles/successful_response (0.00s)
    --- PASS: TestUserProfiles/server_error (0.00s)
    --- PASS: TestUserProfiles/invalid_user_ID (0.00s)
PASS
ok      github.com/doneill/er-cli/api   0.566s
```