### PR TITLE
Fetch subjects updated since

### DIFF
--- a/api/apisubjects.go
+++ b/api/apisubjects.go
@@ -3,7 +3,6 @@ package api
 import (
 	"fmt"
 	"net/url"
-	"time"
 )
 
 // ----------------------------------------------
@@ -11,12 +10,7 @@ import (
 // ----------------------------------------------
 
 type SubjectsResponse struct {
-	Data struct {
-		Count    int       `json:"count"`
-		Next     *string   `json:"next"`
-		Previous *string   `json:"previous"`
-		Results  []Subject `json:"results"`
-	} `json:"data"`
+	Data   []Subject `json:"data"`
 	Status struct {
 		Code    int    `json:"code"`
 		Message string `json:"message"`
@@ -68,16 +62,10 @@ type Coordinate struct {
 // Client methods
 // ----------------------------------------------
 
-func (c *Client) Subjects() (*SubjectsResponse, error) {
-	// Calculate date 3 days ago
-	threeDaysAgo := time.Now().AddDate(0, 0, -3).UTC()
-	updatedSince := threeDaysAgo.Format("2006-01-02T15:04:05.000")
-
-	// Create query parameters
+func (c *Client) Subjects(updatedSince string) (*SubjectsResponse, error) {
 	params := url.Values{}
 	params.Add("updated_since", updatedSince)
 
-	// Create URL with query parameters
 	endpoint := fmt.Sprintf("%s?%s", API_SUBJECTS, params.Encode())
 
 	req, err := c.newRequest("GET", endpoint, false)

--- a/api/apisubjects.go
+++ b/api/apisubjects.go
@@ -1,0 +1,94 @@
+package api
+
+import (
+	"fmt"
+	"net/url"
+	"time"
+)
+
+// ----------------------------------------------
+// structs
+// ----------------------------------------------
+
+type SubjectsResponse struct {
+	Data struct {
+		Count    int       `json:"count"`
+		Next     *string   `json:"next"`
+		Previous *string   `json:"previous"`
+		Results  []Subject `json:"results"`
+	} `json:"data"`
+	Status struct {
+		Code    int    `json:"code"`
+		Message string `json:"message"`
+	} `json:"status"`
+}
+
+type Subject struct {
+	ID               string       `json:"id"`
+	LastPosition     LastPosition `json:"last_position"`
+	LastPositionDate string       `json:"last_position_date"`
+	Name             string       `json:"name"`
+	SubjectSubtype   string       `json:"subject_subtype"`
+	SubjectType      string       `json:"subject_type"`
+}
+
+type LastPosition struct {
+	Geometry   Geometry   `json:"geometry"`
+	Properties Properties `json:"properties"`
+	Type       string     `json:"type"`
+}
+
+type Geometry struct {
+	Coordinates []float64 `json:"coordinates"`
+	Type        string    `json:"type"`
+}
+
+type Properties struct {
+	DateTime             string     `json:"DateTime"`
+	CoordinateProperties Coordinate `json:"coordinateProperties"`
+	ID                   string     `json:"id"`
+	Image                string     `json:"image"`
+	LastVoiceCallStartAt *string    `json:"last_voice_call_start_at"`
+	LocationRequestedAt  *string    `json:"location_requested_at"`
+	RadioState           string     `json:"radio_state"`
+	RadioStateAt         string     `json:"radio_state_at"`
+	Stroke               string     `json:"stroke"`
+	StrokeOpacity        float64    `json:"stroke-opacity"`
+	StrokeWidth          int        `json:"stroke-width"`
+	SubjectSubtype       string     `json:"subject_subtype"`
+	SubjectType          string     `json:"subject_type"`
+	Title                string     `json:"title"`
+}
+
+type Coordinate struct {
+	Time string `json:"time"`
+}
+
+// ----------------------------------------------
+// Client methods
+// ----------------------------------------------
+
+func (c *Client) Subjects() (*SubjectsResponse, error) {
+	// Calculate date 3 days ago
+	threeDaysAgo := time.Now().AddDate(0, 0, -3).UTC()
+	updatedSince := threeDaysAgo.Format("2006-01-02T15:04:05.000")
+
+	// Create query parameters
+	params := url.Values{}
+	params.Add("updated_since", updatedSince)
+
+	// Create URL with query parameters
+	endpoint := fmt.Sprintf("%s?%s", API_SUBJECTS, params.Encode())
+
+	req, err := c.newRequest("GET", endpoint, false)
+	if err != nil {
+		return nil, fmt.Errorf("error generating subjects request: %w", err)
+	}
+
+	var responseData SubjectsResponse
+	if err := c.doRequest(req, &responseData); err != nil {
+		return nil, fmt.Errorf("error fetching subjects: %w", err)
+	}
+
+	return &responseData, nil
+}

--- a/api/ersvc.go
+++ b/api/ersvc.go
@@ -16,6 +16,8 @@ const API_V1 = "/api/v1.0"
 
 const API_AUTH = "/oauth2/token"
 
+const API_SUBJECTS = API_V1 + "/subjects"
+
 const API_USER = API_V1 + "/user"
 
 const API_USER_ME = API_USER + "/me"

--- a/api/subjects_test.go
+++ b/api/subjects_test.go
@@ -1,0 +1,126 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestSubjects(t *testing.T) {
+	tests := []struct {
+		name           string
+		serverResponse *SubjectsResponse
+		statusCode     int
+		expectError    bool
+	}{
+		{
+			name: "successful response",
+			serverResponse: &SubjectsResponse{
+				Data: struct {
+					Count    int       `json:"count"`
+					Next     *string   `json:"next"`
+					Previous *string   `json:"previous"`
+					Results  []Subject `json:"results"`
+				}{
+					Count: 1,
+					Results: []Subject{
+						{
+							ID: "123778d5-ffcc-4911-8d3b-e43cfdb426f7",
+							LastPosition: LastPosition{
+								Geometry: Geometry{
+									Coordinates: []float64{-121.6670876888658, 47.44309785582009},
+									Type:        "Point",
+								},
+								Type: "Feature",
+							},
+							LastPositionDate: "2024-12-23T18:34:51+00:00",
+							Name:             "Test Subject",
+							SubjectSubtype:   "ranger",
+							SubjectType:      "person",
+						},
+					},
+				},
+				Status: struct {
+					Code    int    `json:"code"`
+					Message string `json:"message"`
+				}{
+					Code:    200,
+					Message: "OK",
+				},
+			},
+			statusCode:  http.StatusOK,
+			expectError: false,
+		},
+		{
+			name:           "server error",
+			serverResponse: nil,
+			statusCode:     http.StatusInternalServerError,
+			expectError:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Method != http.MethodGet {
+					t.Errorf("expected GET request, got %s", r.Method)
+				}
+				if r.Header.Get("Authorization") != "Bearer testtoken" {
+					t.Errorf("expected Bearer testtoken, got %s", r.Header.Get("Authorization"))
+				}
+
+				query := r.URL.Query()
+				updatedSince := query.Get("updated_since")
+				if updatedSince == "" {
+					t.Error("expected updated_since parameter, got none")
+				}
+
+				updatedSinceTime, err := time.Parse("2006-01-02T15:04:05.000", updatedSince)
+				if err != nil {
+					t.Errorf("invalid date format: %v", err)
+				}
+				expectedTime := time.Now().AddDate(0, 0, -3)
+				if updatedSinceTime.Day() != expectedTime.Day() {
+					t.Errorf("expected date around %v, got %v", expectedTime, updatedSinceTime)
+				}
+
+				w.WriteHeader(tt.statusCode)
+				if tt.serverResponse != nil {
+					if err := json.NewEncoder(w).Encode(tt.serverResponse); err != nil {
+						t.Errorf("failed to encode response: %v", err)
+						return
+					}
+				}
+			}))
+			defer server.Close()
+
+			client := ERClient("test", "testtoken", server.URL)
+			resp, err := client.Subjects()
+
+			if tt.expectError && err == nil {
+				t.Error("expected error, got nil")
+			}
+			if !tt.expectError && err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+
+			if !tt.expectError {
+				if resp == nil {
+					t.Fatal("expected response, got nil")
+				}
+				if len(resp.Data.Results) != len(tt.serverResponse.Data.Results) {
+					t.Errorf("expected %d subjects, got %d",
+						len(tt.serverResponse.Data.Results), len(resp.Data.Results))
+				}
+				if len(resp.Data.Results) > 0 {
+					if resp.Data.Results[0].ID != tt.serverResponse.Data.Results[0].ID {
+						t.Errorf("expected subject ID %s, got %s",
+							tt.serverResponse.Data.Results[0].ID, resp.Data.Results[0].ID)
+					}
+				}
+			}
+		})
+	}
+}

--- a/cmd/subjects.go
+++ b/cmd/subjects.go
@@ -1,0 +1,103 @@
+package cmd
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"time"
+
+	"github.com/doneill/er-cli/api"
+	"github.com/doneill/er-cli/config"
+	"github.com/olekukonko/tablewriter"
+	"github.com/spf13/cobra"
+)
+
+var daysAgo int
+
+// ----------------------------------------------
+// subjects command
+// ----------------------------------------------
+
+var subjectsCmd = &cobra.Command{
+	Use:   "subjects",
+	Short: "Get updated subjects data",
+	Long:  `Return subject data updated within specified number of days ago`,
+	Run: func(cmd *cobra.Command, args []string) {
+		subjects()
+	},
+}
+
+// ----------------------------------------------
+// functions
+// ----------------------------------------------
+
+func subjects() {
+	updatedSince := time.Now().AddDate(0, 0, -daysAgo).UTC().Format("2006-01-02T15:04:05.000")
+	client := api.ERClient(config.Sitename(), config.Token())
+
+	subjectsResponse, err := client.Subjects(updatedSince)
+	if err != nil {
+		log.Fatalf("Error getting subjects: %v", err)
+	}
+
+	if subjectsResponse == nil || len(subjectsResponse.Data) == 0 {
+		fmt.Println("No subjects found")
+		return
+	}
+
+	table := configureSubjectsTable()
+	for _, subject := range subjectsResponse.Data {
+		table.Append(formatSubjectData(&subject))
+	}
+
+	table.Render()
+}
+
+func formatSubjectData(subject *api.Subject) []string {
+	coordinates := "N/A"
+
+	if len(subject.LastPosition.Geometry.Coordinates) >= 2 {
+		coordinates = fmt.Sprintf("%.6f, %.6f",
+			subject.LastPosition.Geometry.Coordinates[1],
+			subject.LastPosition.Geometry.Coordinates[0],
+		)
+	}
+
+	return []string{
+		subject.Name,
+		subject.ID,
+		subject.SubjectType,
+		subject.SubjectSubtype,
+		subject.LastPositionDate,
+		coordinates,
+	}
+}
+
+func configureSubjectsTable() *tablewriter.Table {
+	table := tablewriter.NewWriter(os.Stdout)
+	table.SetHeader([]string{
+		"Name",
+		"ID",
+		"Type",
+		"Subtype",
+		"Last Position Date",
+		"Last Position (lat, lon)",
+	})
+	table.SetBorders(tablewriter.Border{
+		Left:   true,
+		Top:    true,
+		Right:  true,
+		Bottom: true,
+	})
+	table.SetCenterSeparator("|")
+	return table
+}
+
+// ----------------------------------------------
+// initialize
+// ----------------------------------------------
+
+func init() {
+	rootCmd.AddCommand(subjectsCmd)
+	subjectsCmd.Flags().IntVarP(&daysAgo, "updated-since", "u", 3, "Number of days ago to query updates from")
+}


### PR DESCRIPTION
Add `subjects` command with flag to set the response to subjects that have been updated since `X` number of days ago

```
er subjects --help
Return subject data updated within specified number of days ago

Usage:
  er subjects [flags]

Flags:
  -h, --help                help for subjects
  -u, --updated-since int   Number of days ago to query updates from (default 3)
```