### PR TITLE
Add tracks flag to subjects command

### DIFF
--- a/api/apisubjects.go
+++ b/api/apisubjects.go
@@ -3,6 +3,8 @@ package api
 import (
 	"fmt"
 	"net/url"
+	"path"
+	"time"
 )
 
 // ----------------------------------------------
@@ -58,6 +60,46 @@ type Coordinate struct {
 	Time string `json:"time"`
 }
 
+type TracksResponse struct {
+	Data struct {
+		Features []Feature `json:"features"`
+		Type     string    `json:"type"`
+	} `json:"data"`
+	Status struct {
+		Code    int    `json:"code"`
+		Message string `json:"message"`
+	} `json:"status"`
+}
+
+type Feature struct {
+	Geometry   TrackGeometry   `json:"geometry"`
+	Properties TrackProperties `json:"properties"`
+	Type       string          `json:"type"`
+}
+
+type TrackGeometry struct {
+	Coordinates [][]float64 `json:"coordinates"`
+	Type        string      `json:"type"`
+}
+
+type TrackProperties struct {
+	CoordinateProperties struct {
+		Times []string `json:"times"`
+	} `json:"coordinateProperties"`
+	ID                   string  `json:"id"`
+	Image                string  `json:"image"`
+	LastVoiceCallStartAt *string `json:"last_voice_call_start_at"`
+	LocationRequestedAt  *string `json:"location_requested_at"`
+	RadioState           string  `json:"radio_state"`
+	RadioStateAt         string  `json:"radio_state_at"`
+	Stroke               string  `json:"stroke"`
+	StrokeOpacity        float64 `json:"stroke-opacity"`
+	StrokeWidth          int     `json:"stroke-width"`
+	SubjectSubtype       string  `json:"subject_subtype"`
+	SubjectType          string  `json:"subject_type"`
+	Title                string  `json:"title"`
+}
+
 // ----------------------------------------------
 // Client methods
 // ----------------------------------------------
@@ -76,6 +118,28 @@ func (c *Client) Subjects(updatedSince string) (*SubjectsResponse, error) {
 	var responseData SubjectsResponse
 	if err := c.doRequest(req, &responseData); err != nil {
 		return nil, fmt.Errorf("error fetching subjects: %w", err)
+	}
+
+	return &responseData, nil
+}
+
+func (c *Client) SubjectTracks(subjectID string, daysAgo int) (*TracksResponse, error) {
+	sinceDate := time.Now().AddDate(0, 0, -daysAgo).UTC().Format("2006-01-02T15:04:05+00:00")
+
+	params := url.Values{}
+	params.Add("since", sinceDate)
+
+	endpoint := path.Join(API_SUBJECT, subjectID, API_SUBJECT_TRACKS)
+	endpoint = fmt.Sprintf("%s?%s", endpoint, params.Encode())
+
+	req, err := c.newRequest("GET", endpoint, false)
+	if err != nil {
+		return nil, fmt.Errorf("error generating tracks request: %w", err)
+	}
+
+	var responseData TracksResponse
+	if err := c.doRequest(req, &responseData); err != nil {
+		return nil, fmt.Errorf("error fetching tracks: %w", err)
 	}
 
 	return &responseData, nil

--- a/api/ersvc.go
+++ b/api/ersvc.go
@@ -16,7 +16,11 @@ const API_V1 = "/api/v1.0"
 
 const API_AUTH = "/oauth2/token"
 
+const API_SUBJECT = API_V1 + "/subject"
+
 const API_SUBJECTS = API_V1 + "/subjects"
+
+const API_SUBJECT_TRACKS = "/tracks"
 
 const API_USER = API_V1 + "/user"
 

--- a/api/subjects_test.go
+++ b/api/subjects_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"path"
 	"strings"
 	"testing"
 	"time"
@@ -149,6 +150,153 @@ func TestSubjects(t *testing.T) {
 				if resp.Status.Code != tt.serverResponse.Status.Code {
 					t.Errorf("expected status code %d, got %d",
 						tt.serverResponse.Status.Code, resp.Status.Code)
+				}
+			}
+		})
+	}
+}
+
+func TestSubjectTracks(t *testing.T) {
+	tests := []struct {
+		name           string
+		subjectID      string
+		daysAgo        int
+		serverResponse *TracksResponse
+		statusCode     int
+		expectError    bool
+	}{
+		{
+			name:      "successful response",
+			subjectID: "123778d5-ffcc-4911-8d3b-e43cfdb426f7",
+			daysAgo:   3,
+			serverResponse: &TracksResponse{
+				Data: struct {
+					Features []Feature `json:"features"`
+					Type     string    `json:"type"`
+				}{
+					Features: []Feature{
+						{
+							Geometry: TrackGeometry{
+								Coordinates: [][]float64{
+									{-121.6670876888658, 47.44309785582009},
+									{-121.6695629568987, 47.44295692585065},
+								},
+								Type: "LineString",
+							},
+							Properties: TrackProperties{
+								CoordinateProperties: struct {
+									Times []string `json:"times"`
+								}{
+									Times: []string{
+										"2024-12-23T18:34:51+00:00",
+										"2024-12-23T18:34:45+00:00",
+									},
+								},
+								ID:             "123778d5-ffcc-4911-8d3b-e43cfdb426f7",
+								Title:          "Test Subject",
+								SubjectType:    "person",
+								SubjectSubtype: "ranger",
+							},
+							Type: "Feature",
+						},
+					},
+					Type: "FeatureCollection",
+				},
+				Status: struct {
+					Code    int    `json:"code"`
+					Message string `json:"message"`
+				}{
+					Code:    200,
+					Message: "OK",
+				},
+			},
+			statusCode:  http.StatusOK,
+			expectError: false,
+		},
+		{
+			name:           "subject not found",
+			subjectID:      "nonexistent",
+			daysAgo:        3,
+			serverResponse: nil,
+			statusCode:     http.StatusNotFound,
+			expectError:    true,
+		},
+		{
+			name:           "empty subject ID",
+			subjectID:      "",
+			daysAgo:        3,
+			serverResponse: nil,
+			statusCode:     http.StatusBadRequest,
+			expectError:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Method != http.MethodGet {
+					t.Errorf("expected GET request, got %s", r.Method)
+				}
+				if r.Header.Get("Authorization") != "Bearer testtoken" {
+					t.Errorf("expected Bearer testtoken, got %s", r.Header.Get("Authorization"))
+				}
+
+				expectedPath := path.Join(API_SUBJECT, tt.subjectID, API_SUBJECT_TRACKS)
+				if !strings.HasSuffix(r.URL.Path, expectedPath) {
+					t.Errorf("expected path to end with %s, got %s", expectedPath, r.URL.Path)
+				}
+
+				query := r.URL.Query()
+				since := query.Get("since")
+				if since == "" {
+					t.Error("expected since parameter, got none")
+				}
+
+				_, err := time.Parse("2006-01-02T15:04:05+00:00", since)
+				if err != nil {
+					t.Errorf("invalid date format: %v", err)
+				}
+
+				w.WriteHeader(tt.statusCode)
+				if tt.serverResponse != nil {
+					if err := json.NewEncoder(w).Encode(tt.serverResponse); err != nil {
+						t.Errorf("failed to encode response: %v", err)
+						return
+					}
+				}
+			}))
+			defer server.Close()
+
+			client := ERClient("test", "testtoken", server.URL)
+			resp, err := client.SubjectTracks(tt.subjectID, tt.daysAgo)
+
+			if tt.expectError && err == nil {
+				t.Error("expected error, got nil")
+			}
+			if !tt.expectError && err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+
+			if !tt.expectError && tt.serverResponse != nil {
+				if resp == nil {
+					t.Fatal("expected response, got nil")
+				}
+
+				if len(resp.Data.Features) != len(tt.serverResponse.Data.Features) {
+					t.Errorf("expected %d features, got %d",
+						len(tt.serverResponse.Data.Features), len(resp.Data.Features))
+				}
+
+				if len(resp.Data.Features) > 0 {
+					if resp.Data.Features[0].Type != tt.serverResponse.Data.Features[0].Type {
+						t.Errorf("expected feature type %s, got %s",
+							tt.serverResponse.Data.Features[0].Type, resp.Data.Features[0].Type)
+					}
+
+					if len(resp.Data.Features[0].Geometry.Coordinates) !=
+						len(tt.serverResponse.Data.Features[0].Geometry.Coordinates) {
+						t.Error("coordinates length mismatch")
+					}
 				}
 			}
 		})

--- a/cmd/subjects.go
+++ b/cmd/subjects.go
@@ -1,9 +1,11 @@
 package cmd
 
 import (
+	"encoding/json"
 	"fmt"
 	"log"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/doneill/er-cli/api"
@@ -12,7 +14,12 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var daysAgo int
+var (
+	daysAgo   int
+	tracks    bool
+	subjectID string
+	export    bool
+)
 
 // ----------------------------------------------
 // subjects command
@@ -20,8 +27,8 @@ var daysAgo int
 
 var subjectsCmd = &cobra.Command{
 	Use:   "subjects",
-	Short: "Get updated subjects data",
-	Long:  `Return subject data updated within specified number of days ago`,
+	Short: "Get subjects data and tracks",
+	Long:  `Return subject data and tracks updated within specified number of days ago`,
 	Run: func(cmd *cobra.Command, args []string) {
 		subjects()
 	},
@@ -32,8 +39,62 @@ var subjectsCmd = &cobra.Command{
 // ----------------------------------------------
 
 func subjects() {
-	updatedSince := time.Now().AddDate(0, 0, -daysAgo).UTC().Format("2006-01-02T15:04:05.000")
 	client := api.ERClient(config.Sitename(), config.Token())
+
+	switch {
+	case tracks:
+		if subjectID == "" {
+			log.Fatal("Subject ID is required when using tracks flag")
+		}
+		handleTracks(client)
+	default:
+		handleSubjects(client)
+	}
+}
+
+func handleTracks(client *api.Client) {
+	tracksResponse, err := client.SubjectTracks(subjectID, daysAgo)
+	if err != nil {
+		if strings.Contains(err.Error(), "404") {
+			log.Fatalf("Subject ID %s not found. Use 'er subjects' command to list available subjects", subjectID)
+		}
+		log.Fatalf("Error getting tracks: %v", err)
+	}
+
+	if tracksResponse == nil || len(tracksResponse.Data.Features) == 0 {
+		fmt.Println("No tracks found")
+		return
+	}
+
+	// Create a GeoJSON structure
+	geoJSON := struct {
+		Type     string        `json:"type"`
+		Features []api.Feature `json:"features"`
+	}{
+		Type:     tracksResponse.Data.Type,
+		Features: tracksResponse.Data.Features,
+	}
+
+	// Marshal to JSON with indentation
+	jsonData, err := json.MarshalIndent(geoJSON, "", "    ")
+	if err != nil {
+		log.Fatalf("Error formatting JSON: %v", err)
+	}
+
+	if export {
+		filename := fmt.Sprintf("%s.geojson", subjectID)
+		if err := os.WriteFile(filename, jsonData, 0644); err != nil {
+			log.Fatalf("Error writing file: %v", err)
+		}
+		fmt.Printf("Successfully exported tracks to %s\n", filename)
+	} else {
+		fmt.Println(string(jsonData))
+	}
+}
+
+func handleSubjects(client *api.Client) {
+	// Calculate the date from days ago
+	updatedSince := time.Now().AddDate(0, 0, -daysAgo).UTC().Format("2006-01-02T15:04:05.000")
 
 	subjectsResponse, err := client.Subjects(updatedSince)
 	if err != nil {
@@ -49,7 +110,6 @@ func subjects() {
 	for _, subject := range subjectsResponse.Data {
 		table.Append(formatSubjectData(&subject))
 	}
-
 	table.Render()
 }
 
@@ -100,4 +160,7 @@ func configureSubjectsTable() *tablewriter.Table {
 func init() {
 	rootCmd.AddCommand(subjectsCmd)
 	subjectsCmd.Flags().IntVarP(&daysAgo, "updated-since", "u", 3, "Number of days ago to query updates from")
+	subjectsCmd.Flags().BoolVarP(&tracks, "tracks", "t", false, "Get tracks for a subject")
+	subjectsCmd.Flags().StringVarP(&subjectID, "subject-id", "s", "", "Subject ID for tracks query")
+	subjectsCmd.Flags().BoolVarP(&export, "export", "e", false, "Export tracks to GeoJSON file")
 }


### PR DESCRIPTION
- Add subject tracks flag
  - Print to screen or export to file
- Add tracks flag test to subjects

```
er subjects --help
Return subject data and tracks updated within specified number of days ago

Usage:
  er subjects [flags]

Flags:
  -e, --export              Export tracks to GeoJSON file
  -h, --help                help for subjects
  -s, --subject-id string   Subject ID for tracks query
  -t, --tracks              Get tracks for a subject
  -u, --updated-since int   Number of days ago to query updates from (default 3)

> er subjects -s [SUBJECT_ID] -t -u 3 -e
Successfully exported tracks to [SUBJECT_ID].geojson
```

