### PR TITLE
Add patrols status flag

### DIFF
--- a/api/apipatrols.go
+++ b/api/apipatrols.go
@@ -63,8 +63,13 @@ type DateRangeFilter struct {
 // Client methods
 // ----------------------------------------------
 
-func (c *Client) Patrols(days int) (*PatrolsResponse, error) {
-	var endpoint string
+func (c *Client) Patrols(days int, status string) (*PatrolsResponse, error) {
+	params := url.Values{}
+	params.Add("exclude_empty_patrols", "true")
+
+	if status != "" {
+		params.Add("status", status)
+	}
 
 	if days > 0 {
 		now := time.Now().UTC()
@@ -82,14 +87,10 @@ func (c *Client) Patrols(days int) (*PatrolsResponse, error) {
 			return nil, fmt.Errorf("failed to marshal date filter: %w", err)
 		}
 
-		params := url.Values{}
 		params.Add("filter", string(filterJSON))
-		params.Add("exclude_empty_patrols", "true")
-
-		endpoint = fmt.Sprintf("%s?%s", API_PATROLS, params.Encode())
-	} else {
-		endpoint = fmt.Sprintf("%s?exclude_empty_patrols=true", API_PATROLS)
 	}
+
+	endpoint := fmt.Sprintf("%s?%s", API_PATROLS, params.Encode())
 
 	req, err := c.newRequest("GET", endpoint, false)
 	if err != nil {


### PR DESCRIPTION
Add status flag to filter resopnse by status

```shell
> er patrols --help
Return patrol data including serial number, state, ID, location, and time information

Usage:
  er patrols [flags]

Flags:
  -d, --days int        Number of days to fetch patrols for (default 7)
  -h, --help            help for patrols
  -s, --status string   Patrol status (active, done, or cancelled)
```

Ensure inputs are valid status strings

```bash
> er patrols -d 3 -s open
Error: invalid status value: open
Valid status values are: active, done, cancelled
Usage:
  er patrols [flags]

Flags:
  -d, --days int        Number of days to fetch patrols for (default 7)
  -h, --help            help for patrols
  -s, --status string   Patrol status (active, done, or cancelled)
```