### PR TITLE
Modularize geojson into utilty

### DIFF
--- a/cmd/subjects.go
+++ b/cmd/subjects.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"encoding/json"
 	"fmt"
 	"log"
 	"os"
@@ -10,6 +9,7 @@ import (
 
 	"github.com/doneill/er-cli/api"
 	"github.com/doneill/er-cli/config"
+	"github.com/doneill/er-cli/utils"
 	"github.com/olekukonko/tablewriter"
 	"github.com/spf13/cobra"
 )
@@ -66,29 +66,42 @@ func handleTracks(client *api.Client) {
 		return
 	}
 
-	// Create a GeoJSON structure
-	geoJSON := struct {
-		Type     string        `json:"type"`
-		Features []api.Feature `json:"features"`
-	}{
-		Type:     tracksResponse.Data.Type,
-		Features: tracksResponse.Data.Features,
-	}
-
-	// Marshal to JSON with indentation
-	jsonData, err := json.MarshalIndent(geoJSON, "", "    ")
-	if err != nil {
-		log.Fatalf("Error formatting JSON: %v", err)
-	}
-
-	if export {
-		filename := fmt.Sprintf("%s.geojson", subjectID)
-		if err := os.WriteFile(filename, jsonData, 0644); err != nil {
-			log.Fatalf("Error writing file: %v", err)
+	var geoJSONFeatures []utils.Feature
+	for _, feature := range tracksResponse.Data.Features {
+		geoJSONFeature := utils.Feature{
+			Type: feature.Type,
+			Geometry: utils.Geometry{
+				Type:        feature.Geometry.Type,
+				Coordinates: feature.Geometry.Coordinates,
+			},
+			Properties: map[string]interface{}{
+				"id":                       feature.Properties.ID,
+				"title":                    feature.Properties.Title,
+				"subject_type":             feature.Properties.SubjectType,
+				"subject_subtype":          feature.Properties.SubjectSubtype,
+				"stroke":                   feature.Properties.Stroke,
+				"stroke_opacity":           feature.Properties.StrokeOpacity,
+				"stroke_width":             feature.Properties.StrokeWidth,
+				"coordinate_properties":    feature.Properties.CoordinateProperties,
+				"image":                    feature.Properties.Image,
+				"radio_state":              feature.Properties.RadioState,
+				"radio_state_at":           feature.Properties.RadioStateAt,
+				"last_voice_call_start_at": feature.Properties.LastVoiceCallStartAt,
+				"location_requested_at":    feature.Properties.LocationRequestedAt,
+			},
 		}
-		fmt.Printf("Successfully exported tracks to %s\n", filename)
-	} else {
-		fmt.Println(string(jsonData))
+		geoJSONFeatures = append(geoJSONFeatures, geoJSONFeature)
+	}
+
+	featureCollection := utils.NewFeatureCollection(geoJSONFeatures)
+
+	var filename string
+	if export {
+		filename = fmt.Sprintf("%s.geojson", subjectID)
+	}
+
+	if err := utils.ExportToFile(featureCollection, filename); err != nil {
+		log.Fatalf("Error exporting GeoJSON: %v", err)
 	}
 }
 

--- a/cmd/subjects.go
+++ b/cmd/subjects.go
@@ -66,41 +66,12 @@ func handleTracks(client *api.Client) {
 		return
 	}
 
-	var geoJSONFeatures []utils.Feature
-	for _, feature := range tracksResponse.Data.Features {
-		geoJSONFeature := utils.Feature{
-			Type: feature.Type,
-			Geometry: utils.Geometry{
-				Type:        feature.Geometry.Type,
-				Coordinates: feature.Geometry.Coordinates,
-			},
-			Properties: map[string]interface{}{
-				"id":                       feature.Properties.ID,
-				"title":                    feature.Properties.Title,
-				"subject_type":             feature.Properties.SubjectType,
-				"subject_subtype":          feature.Properties.SubjectSubtype,
-				"stroke":                   feature.Properties.Stroke,
-				"stroke_opacity":           feature.Properties.StrokeOpacity,
-				"stroke_width":             feature.Properties.StrokeWidth,
-				"coordinate_properties":    feature.Properties.CoordinateProperties,
-				"image":                    feature.Properties.Image,
-				"radio_state":              feature.Properties.RadioState,
-				"radio_state_at":           feature.Properties.RadioStateAt,
-				"last_voice_call_start_at": feature.Properties.LastVoiceCallStartAt,
-				"location_requested_at":    feature.Properties.LocationRequestedAt,
-			},
-		}
-		geoJSONFeatures = append(geoJSONFeatures, geoJSONFeature)
-	}
-
-	featureCollection := utils.NewFeatureCollection(geoJSONFeatures)
-
 	var filename string
 	if export {
 		filename = fmt.Sprintf("%s.geojson", subjectID)
 	}
 
-	if err := utils.ExportToFile(featureCollection, filename); err != nil {
+	if err := utils.ExportToFile(tracksResponse.Data, filename); err != nil {
 		log.Fatalf("Error exporting GeoJSON: %v", err)
 	}
 }

--- a/utils/geojson.go
+++ b/utils/geojson.go
@@ -1,0 +1,82 @@
+package utils
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+)
+
+// ----------------------------------------------
+// GeoJSON types
+// ----------------------------------------------
+
+type FeatureCollection struct {
+	Type     string    `json:"type"`
+	Features []Feature `json:"features"`
+}
+
+type Feature struct {
+	Type       string                 `json:"type"`
+	Geometry   Geometry               `json:"geometry"`
+	Properties map[string]interface{} `json:"properties"`
+}
+
+type Geometry struct {
+	Type        string      `json:"type"`
+	Coordinates interface{} `json:"coordinates"`
+}
+
+// ----------------------------------------------
+// GeoJSON creation functions
+// ----------------------------------------------
+
+func NewFeatureCollection(features []Feature) FeatureCollection {
+	return FeatureCollection{
+		Type:     "FeatureCollection",
+		Features: features,
+	}
+}
+
+func NewPointFeature(lat, lon float64, properties map[string]interface{}) Feature {
+	return Feature{
+		Type: "Feature",
+		Geometry: Geometry{
+			Type:        "Point",
+			Coordinates: []float64{lon, lat},
+		},
+		Properties: properties,
+	}
+}
+
+func NewLineStringFeature(coordinates [][]float64, properties map[string]interface{}) Feature {
+	return Feature{
+		Type: "Feature",
+		Geometry: Geometry{
+			Type:        "LineString",
+			Coordinates: coordinates,
+		},
+		Properties: properties,
+	}
+}
+
+// ----------------------------------------------
+// Export functions
+// ----------------------------------------------
+
+func ExportToFile(data interface{}, filename string) error {
+	jsonData, err := json.MarshalIndent(data, "", "    ")
+	if err != nil {
+		return fmt.Errorf("error formatting JSON: %w", err)
+	}
+
+	if filename != "" {
+		if err := os.WriteFile(filename, jsonData, 0644); err != nil {
+			return fmt.Errorf("error writing file: %w", err)
+		}
+		fmt.Printf("Successfully exported to %s\n", filename)
+	} else {
+		fmt.Println(string(jsonData))
+	}
+
+	return nil
+}


### PR DESCRIPTION
Created a geojson utility for future user, for subject tracks reverted to the API response

**Proposed Changes**
- Create generic geojson utils source
- Create `ExportToFile` to create the geojson files
- Removed redundate conversion code

**Expectation:**
- Exporting subject tracks by id works as expected

```
# generated tracks for last 3 days
er subjects -s {subject-id} -t -u 3 -e
```

- All subjects test pass

```
=== RUN   TestSubjects
=== RUN   TestSubjects/successful_response
=== RUN   TestSubjects/server_error
=== RUN   TestSubjects/empty_response
--- PASS: TestSubjects (0.00s)
    --- PASS: TestSubjects/successful_response (0.00s)
    --- PASS: TestSubjects/server_error (0.00s)
    --- PASS: TestSubjects/empty_response (0.00s)
=== RUN   TestSubjectTracks
=== RUN   TestSubjectTracks/successful_response
=== RUN   TestSubjectTracks/subject_not_found
=== RUN   TestSubjectTracks/empty_subject_ID
--- PASS: TestSubjectTracks (0.00s)
    --- PASS: TestSubjectTracks/successful_response (0.00s)
    --- PASS: TestSubjectTracks/subject_not_found (0.00s)
    --- PASS: TestSubjectTracks/empty_subject_ID (0.00s)
```

