### PR TITLE
Update patrol segment data

### DIFF
--- a/api/apipatrols.go
+++ b/api/apipatrols.go
@@ -33,12 +33,13 @@ type Patrol struct {
 }
 
 type PatrolSegment struct {
-	ID     string `json:"id"`
+	ID            string    `json:"id"`
 	Leader *struct {
 		Name string `json:"name"`
 	} `json:"leader"`
 	PatrolType    string    `json:"patrol_type"`
 	StartLocation *Location `json:"start_location"`
+	EndLocation   *Location `json:"end_location"`
 	TimeRange     TimeRange `json:"time_range"`
 }
 

--- a/api/apipatrols.go
+++ b/api/apipatrols.go
@@ -33,6 +33,7 @@ type Patrol struct {
 }
 
 type PatrolSegment struct {
+	ID     string `json:"id"`
 	Leader *struct {
 		Name string `json:"name"`
 	} `json:"leader"`

--- a/api/patrols_test.go
+++ b/api/patrols_test.go
@@ -36,12 +36,14 @@ func TestPatrols(t *testing.T) {
                             "title": "Test Patrol",
                             "patrol_segments": [
                                 {
+                                    "id": "segment123",
                                     "leader": {"name": "John Doe"},
                                     "patrol_type": "boat_patrol",
                                     "start_location": {"latitude": 1.234, "longitude": 5.678},
+                                    "end_location": null,
                                     "time_range": {
                                         "start_time": "2025-01-15T10:00:00.000Z",
-                                        "end_time": "2025-01-15T11:00:00.000Z"
+                                        "end_time": null
                                     }
                                 }
                             ]
@@ -82,16 +84,27 @@ func TestPatrols(t *testing.T) {
 				if len(patrol.PatrolSegments) == 0 {
 					t.Fatal("Expected at least one patrol segment")
 				}
-				if patrol.PatrolSegments[0].Leader == nil {
+				segment := patrol.PatrolSegments[0]
+				if segment.ID != "segment123" {
+					t.Errorf("Expected segment ID 'segment123', got '%s'", segment.ID)
+				}
+				if segment.Leader == nil {
 					t.Fatal("Expected non-nil leader")
 				}
-				if patrol.PatrolSegments[0].Leader.Name != "John Doe" {
-					t.Errorf("Expected leader name 'John Doe', got '%s'", patrol.PatrolSegments[0].Leader.Name)
+				if segment.Leader.Name != "John Doe" {
+					t.Errorf("Expected leader name 'John Doe', got '%s'", segment.Leader.Name)
+				}
+				// Open patrol should not have end location or end time
+				if segment.EndLocation != nil {
+					t.Error("Expected nil end location for open patrol")
+				}
+				if segment.TimeRange.EndTime != nil {
+					t.Error("Expected nil end time for open patrol")
 				}
 			},
 		},
 		{
-			name:   "successful response with date filter",
+			name:   "successful response with done patrol having end location and time",
 			days:   7,
 			status: "",
 			mockResponse: `{
@@ -101,7 +114,21 @@ func TestPatrols(t *testing.T) {
                         {
                             "id": "test456",
                             "serial_number": 1002,
-                            "state": "closed"
+                            "state": "done",
+                            "title": "Completed Patrol",
+                            "patrol_segments": [
+                                {
+                                    "id": "segment456",
+                                    "leader": {"name": "Jane Smith"},
+                                    "patrol_type": "foot_patrol",
+                                    "start_location": {"latitude": 2.345, "longitude": 6.789},
+                                    "end_location": {"latitude": 2.355, "longitude": 6.799},
+                                    "time_range": {
+                                        "start_time": "2025-01-15T10:00:00.000Z",
+                                        "end_time": "2025-01-15T14:00:00.000Z"
+                                    }
+                                }
+                            ]
                         }
                     ]
                 },
@@ -129,6 +156,33 @@ func TestPatrols(t *testing.T) {
 				if len(response.Data.Results) != 1 {
 					t.Errorf("Expected 1 result, got %d", len(response.Data.Results))
 				}
+				patrol := response.Data.Results[0]
+				if patrol.State != "done" {
+					t.Errorf("Expected state 'done', got '%s'", patrol.State)
+				}
+				if len(patrol.PatrolSegments) == 0 {
+					t.Fatal("Expected at least one patrol segment")
+				}
+				segment := patrol.PatrolSegments[0]
+				if segment.ID != "segment456" {
+					t.Errorf("Expected segment ID 'segment456', got '%s'", segment.ID)
+				}
+				// Done patrol should have end location and end time
+				if segment.EndLocation == nil {
+					t.Fatal("Expected non-nil end location for done patrol")
+				}
+				if segment.EndLocation.Latitude != 2.355 {
+					t.Errorf("Expected end latitude 2.355, got %f", segment.EndLocation.Latitude)
+				}
+				if segment.EndLocation.Longitude != 6.799 {
+					t.Errorf("Expected end longitude 6.799, got %f", segment.EndLocation.Longitude)
+				}
+				if segment.TimeRange.EndTime == nil {
+					t.Fatal("Expected non-nil end time for done patrol")
+				}
+				if *segment.TimeRange.EndTime != "2025-01-15T14:00:00.000Z" {
+					t.Errorf("Expected end time '2025-01-15T14:00:00.000Z', got '%s'", *segment.TimeRange.EndTime)
+				}
 			},
 		},
 		{
@@ -142,7 +196,19 @@ func TestPatrols(t *testing.T) {
                         {
                             "id": "test789",
                             "serial_number": 1003,
-                            "state": "active"
+                            "state": "active",
+                            "patrol_segments": [
+                                {
+                                    "id": "segment789",
+                                    "patrol_type": "vehicle_patrol",
+                                    "start_location": {"latitude": 3.456, "longitude": 7.890},
+                                    "end_location": null,
+                                    "time_range": {
+                                        "start_time": "2025-01-15T08:00:00.000Z",
+                                        "end_time": null
+                                    }
+                                }
+                            ]
                         }
                     ]
                 },
@@ -170,8 +236,23 @@ func TestPatrols(t *testing.T) {
 				if len(response.Data.Results) != 1 {
 					t.Errorf("Expected 1 result, got %d", len(response.Data.Results))
 				}
-				if response.Data.Results[0].State != "active" {
-					t.Errorf("Expected state 'active', got '%s'", response.Data.Results[0].State)
+				patrol := response.Data.Results[0]
+				if patrol.State != "active" {
+					t.Errorf("Expected state 'active', got '%s'", patrol.State)
+				}
+				if len(patrol.PatrolSegments) == 0 {
+					t.Fatal("Expected at least one patrol segment")
+				}
+				segment := patrol.PatrolSegments[0]
+				if segment.ID != "segment789" {
+					t.Errorf("Expected segment ID 'segment789', got '%s'", segment.ID)
+				}
+				// Active patrol should not have end location or end time
+				if segment.EndLocation != nil {
+					t.Error("Expected nil end location for active patrol")
+				}
+				if segment.TimeRange.EndTime != nil {
+					t.Error("Expected nil end time for active patrol")
 				}
 			},
 		},

--- a/cmd/patrols.go
+++ b/cmd/patrols.go
@@ -86,7 +86,8 @@ func formatTime(timeStr *string) string {
 
 func formatPatrolData(patrol *api.Patrol) []string {
 	leader := "N/A"
-	location := "N/A"
+	startLocation := "N/A"
+	endLocation := "N/A"
 	startTime := "N/A"
 	endTime := "N/A"
 	segmentID := "N/A"
@@ -101,9 +102,15 @@ func formatPatrolData(patrol *api.Patrol) []string {
 		}
 
 		if segment.StartLocation != nil {
-			location = fmt.Sprintf("%.6f, %.6f",
+			startLocation = fmt.Sprintf("%.6f, %.6f",
 				segment.StartLocation.Latitude,
 				segment.StartLocation.Longitude)
+		}
+
+		if segment.EndLocation != nil {
+			endLocation = fmt.Sprintf("%.6f, %.6f",
+				segment.EndLocation.Latitude,
+				segment.EndLocation.Longitude)
 		}
 
 		startTime = formatTime(segment.TimeRange.StartTime)
@@ -122,7 +129,8 @@ func formatPatrolData(patrol *api.Patrol) []string {
 		segmentID,
 		title,
 		leader,
-		location,
+		startLocation,
+		endLocation,
 		startTime,
 		endTime,
 	}
@@ -138,6 +146,7 @@ func configurePatrolsTable() *tablewriter.Table {
 		"Title",
 		"Leader",
 		"Start Location",
+		"End Location",
 		"Start Time",
 		"End Time",
 	})

--- a/cmd/patrols.go
+++ b/cmd/patrols.go
@@ -89,9 +89,11 @@ func formatPatrolData(patrol *api.Patrol) []string {
 	location := "N/A"
 	startTime := "N/A"
 	endTime := "N/A"
+	segmentID := "N/A"
 
 	if len(patrol.PatrolSegments) > 0 {
 		segment := patrol.PatrolSegments[0]
+		segmentID = segment.ID
 
 		if segment.Leader != nil {
 			l := segment.Leader
@@ -117,6 +119,7 @@ func formatPatrolData(patrol *api.Patrol) []string {
 		fmt.Sprintf("%d", patrol.SerialNumber),
 		patrol.State,
 		patrol.ID,
+		segmentID,
 		title,
 		leader,
 		location,
@@ -131,6 +134,7 @@ func configurePatrolsTable() *tablewriter.Table {
 		"Serial",
 		"State",
 		"ID",
+		"Segment ID",
 		"Title",
 		"Leader",
 		"Start Location",


### PR DESCRIPTION
Add patrol segment id and end time to patrols command output

**Proposed Changes**
- Displays both start and end location
- Displays the patrols segment id

**Expectation:**
- Patrol id and end location included in patrols command output

```
# display patrols for last 7 days and status
./er patrols -d 7
|--------|-------|--------------------------------------|--------------------------------------|------------------------|-----------------|------------------------|------------------------|--------------|--------------|
| SERIAL | STATE |                  ID                  |              SEGMENT ID              |         TITLE          |     LEADER      |     START LOCATION     |      END LOCATION      |  START TIME  |   END TIME   |
|--------|-------|--------------------------------------|--------------------------------------|------------------------|-----------------|------------------------|------------------------|--------------|--------------|
```

- Patrols test pass
```
=== RUN   TestPatrols
=== RUN   TestPatrols/successful_response_without_filters
=== RUN   TestPatrols/successful_response_with_done_patrol_having_end_location_and_time
=== RUN   TestPatrols/successful_response_with_status_filter
=== RUN   TestPatrols/error_response
--- PASS: TestPatrols (0.00s)
    --- PASS: TestPatrols/successful_response_without_filters (0.00s)
    --- PASS: TestPatrols/successful_response_with_done_patrol_having_end_location_and_time (0.00s)
    --- PASS: TestPatrols/successful_response_with_status_filter (0.00s)
    --- PASS: TestPatrols/error_response (0.00s)
```

