### PR TITLE
Update patrols data

### DIFF
--- a/api/apipatrols.go
+++ b/api/apipatrols.go
@@ -33,7 +33,7 @@ type Patrol struct {
 }
 
 type PatrolSegment struct {
-	ID            string    `json:"id"`
+	ID     string `json:"id"`
 	Leader *struct {
 		Name string `json:"name"`
 	} `json:"leader"`
@@ -68,6 +68,7 @@ type DateRangeFilter struct {
 func (c *Client) Patrols(days int, status string) (*PatrolsResponse, error) {
 	params := url.Values{}
 	params.Add("exclude_empty_patrols", "true")
+	params.Add("page_size", "200")
 
 	if status != "" {
 		params.Add("status", status)

--- a/api/ersvc.go
+++ b/api/ersvc.go
@@ -1,15 +1,20 @@
 package api
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
+	"net"
 	"net/http"
+	"os"
+	"strings"
 	"time"
 )
 
 // ----------------------------------------------
 // const endpoints
 // ----------------------------------------------
+
 const DOMAIN = ".pamdas.org"
 
 const API_V1 = "/api/v1.0"
@@ -85,7 +90,7 @@ func (c *Client) newRequest(method, endpoint string, isAuth bool) (*http.Request
 func (c *Client) doRequest(req *http.Request, v interface{}) error {
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
-		return fmt.Errorf("failed to make request: %w", err)
+		return c.handleRequestError(err)
 	}
 	defer resp.Body.Close()
 
@@ -98,6 +103,36 @@ func (c *Client) doRequest(req *http.Request, v interface{}) error {
 	}
 
 	return nil
+}
+
+func (c *Client) handleRequestError(err error) error {
+	// Check for timeout errors
+	if os.IsTimeout(err) {
+		return fmt.Errorf("request timed out - try reducing the requested data and/or check your network connection")
+	}
+
+	// Check for context deadline exceeded (another form of timeout)
+	if err == context.DeadlineExceeded || strings.Contains(err.Error(), "context deadline exceeded") {
+		return fmt.Errorf("request timed out - try reducing the date range with --days or check your network connection")
+	}
+
+	// Check for network timeout specifically
+	if netErr, ok := err.(net.Error); ok && netErr.Timeout() {
+		return fmt.Errorf("network timeout - try reducing the date range with --days or check your network connection")
+	}
+
+	// Check for DNS resolution errors
+	if strings.Contains(err.Error(), "no such host") {
+		return fmt.Errorf("unable to connect to EarthRanger server - check your network connection and site name")
+	}
+
+	// Check for connection refused
+	if strings.Contains(err.Error(), "connection refused") {
+		return fmt.Errorf("connection refused - check your network connection and EarthRanger server status")
+	}
+
+	// Default error message for other request failures
+	return fmt.Errorf("failed to connect to EarthRanger server: %v", err)
 }
 
 // ----------------------------------------------

--- a/cmd/patrols.go
+++ b/cmd/patrols.go
@@ -126,13 +126,13 @@ func formatPatrolData(patrol *api.Patrol) []string {
 		fmt.Sprintf("%d", patrol.SerialNumber),
 		patrol.State,
 		patrol.ID,
-		segmentID,
 		title,
 		leader,
 		startLocation,
 		endLocation,
 		startTime,
 		endTime,
+		segmentID,
 	}
 }
 
@@ -142,13 +142,13 @@ func configurePatrolsTable() *tablewriter.Table {
 		"Serial",
 		"State",
 		"ID",
-		"Segment ID",
 		"Title",
 		"Leader",
 		"Start Location",
 		"End Location",
 		"Start Time",
 		"End Time",
+		"Segment ID",
 	})
 	table.SetBorders(tablewriter.Border{
 		Left:   true,

--- a/cmd/patrols.go
+++ b/cmd/patrols.go
@@ -37,6 +37,12 @@ var patrolsCmd = &cobra.Command{
 				return fmt.Errorf("invalid status value: %s\nValid status values are: active, done, cancelled", status)
 			}
 		}
+		if days > 30 {
+			return fmt.Errorf("days value cannot exceed 30 (got %d)", days)
+		}
+		if days < 0 {
+			return fmt.Errorf("days value must be positive (got %d)", days)
+		}
 		return nil
 	},
 	Run: func(cmd *cobra.Command, args []string) {


### PR DESCRIPTION

**Proposed Changes**
- Reorder patrols display table
  - Move patrol segment id to end of display
- Limit patrol `--days` value to `30`
  - Most patrol activity is typically queried for recent periods (1-14 days)
  - Add page_size to get manageable response data
- Handle errors in all requests

**Expectation:**
Usage Examples

  Valid usage:
```
er patrols -d 7   # ✅ Default, works fine
er patrols -d 30  # ✅ Maximum allowed
er patrols -d 15  # ✅ Within limit
```

Invalid usage with helpful errors:
```
er patrols -d 31  # ❌ "days value cannot exceed 30 to prevent timeouts (got 31)"
er patrols -d -5  # ❌ "days value must be positive (got -5)"
```
