### PR TITLE
Generate patrol tracks

### DIFF
--- a/api/apipatrols.go
+++ b/api/apipatrols.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/url"
+	"path"
 	"time"
 )
 
@@ -24,23 +25,44 @@ type PatrolsResponse struct {
 	} `json:"status"`
 }
 
-type Patrol struct {
-	ID             string          `json:"id"`
-	SerialNumber   int             `json:"serial_number"`
-	State          string          `json:"state"`
-	Title          *string         `json:"title"`
-	PatrolSegments []PatrolSegment `json:"patrol_segments"`
+type PatrolByIDResponse struct {
+	Data   PatrolDetails `json:"data"`
+	Status struct {
+		Code    int    `json:"code"`
+		Message string `json:"message"`
+	} `json:"status"`
 }
 
-type PatrolSegment struct {
-	ID     string `json:"id"`
-	Leader *struct {
-		Name string `json:"name"`
-	} `json:"leader"`
-	PatrolType    string    `json:"patrol_type"`
-	StartLocation *Location `json:"start_location"`
-	EndLocation   *Location `json:"end_location"`
-	TimeRange     TimeRange `json:"time_range"`
+type Patrol struct {
+	ID             string                  `json:"id"`
+	SerialNumber   int                     `json:"serial_number"`
+	State          string                  `json:"state"`
+	Title          *string                 `json:"title"`
+	PatrolSegments []PatrolSegmentDetails `json:"patrol_segments"`
+}
+
+type PatrolDetails struct {
+	ID             string                 `json:"id"`
+	SerialNumber   int                    `json:"serial_number"`
+	State          string                 `json:"state"`
+	Title          string                 `json:"title"`
+	PatrolSegments []PatrolSegmentDetails `json:"patrol_segments"`
+}
+
+type PatrolSegmentDetails struct {
+	ID            string       `json:"id"`
+	Leader        PatrolLeader `json:"leader"`
+	PatrolType    string       `json:"patrol_type"`
+	StartLocation *Location    `json:"start_location"`
+	EndLocation   *Location    `json:"end_location"`
+	TimeRange     TimeRange    `json:"time_range"`
+}
+
+type PatrolLeader struct {
+	ID             string `json:"id"`
+	Name           string `json:"name"`
+	SubjectType    string `json:"subject_type"`
+	SubjectSubtype string `json:"subject_subtype"`
 }
 
 type Location struct {
@@ -107,20 +129,40 @@ func (c *Client) Patrols(days int, status string) (*PatrolsResponse, error) {
 
 	return &response, nil
 }
+
 func (c *Client) PatrolTracks(subjectID string, since string, until string) (*TracksResponse, error) {
 	params := url.Values{}
 	params.Add("since", since)
 	params.Add("until", until)
+
 	endpoint := path.Join(API_SUBJECT, subjectID, API_SUBJECT_TRACKS)
 	endpoint = fmt.Sprintf("%s?%s", endpoint, params.Encode())
+
 	req, err := c.newRequest("GET", endpoint, false)
 	if err != nil {
 		return nil, fmt.Errorf("error generating patrol tracks request: %w", err)
 	}
+
 	var responseData TracksResponse
 	if err := c.doRequest(req, &responseData); err != nil {
 		return nil, fmt.Errorf("error fetching patrol tracks: %w", err)
 	}
-}
 
 	return &responseData, nil
+}
+
+func (c *Client) PatrolByID(patrolID string) (*PatrolByIDResponse, error) {
+	endpoint := fmt.Sprintf("%s/%s", API_PATROLS, patrolID)
+
+	req, err := c.newRequest("GET", endpoint, false)
+	if err != nil {
+		return nil, fmt.Errorf("error generating patrol by ID request: %w", err)
+	}
+
+	var responseData PatrolByIDResponse
+	if err := c.doRequest(req, &responseData); err != nil {
+		return nil, fmt.Errorf("error fetching patrol by ID: %w", err)
+	}
+
+	return &responseData, nil
+}

--- a/api/apipatrols.go
+++ b/api/apipatrols.go
@@ -107,3 +107,20 @@ func (c *Client) Patrols(days int, status string) (*PatrolsResponse, error) {
 
 	return &response, nil
 }
+func (c *Client) PatrolTracks(subjectID string, since string, until string) (*TracksResponse, error) {
+	params := url.Values{}
+	params.Add("since", since)
+	params.Add("until", until)
+	endpoint := path.Join(API_SUBJECT, subjectID, API_SUBJECT_TRACKS)
+	endpoint = fmt.Sprintf("%s?%s", endpoint, params.Encode())
+	req, err := c.newRequest("GET", endpoint, false)
+	if err != nil {
+		return nil, fmt.Errorf("error generating patrol tracks request: %w", err)
+	}
+	var responseData TracksResponse
+	if err := c.doRequest(req, &responseData); err != nil {
+		return nil, fmt.Errorf("error fetching patrol tracks: %w", err)
+	}
+}
+
+	return &responseData, nil

--- a/api/ersvc.go
+++ b/api/ersvc.go
@@ -81,7 +81,8 @@ func (c *Client) newRequest(method, endpoint string, isAuth bool) (*http.Request
 	} else {
 		// Regular API request headers
 		req.Header.Set("Authorization", "Bearer "+c.token)
-		req.Header.Set("Cache-control", "no-cache")
+		req.Header.Set("Accept", "application/json")
+		req.Header.Set("User-Agent", "Mozilla/5.0 (compatible; er-cli)")
 	}
 
 	return req, nil

--- a/api/patrols_test.go
+++ b/api/patrols_test.go
@@ -37,7 +37,12 @@ func TestPatrols(t *testing.T) {
                             "patrol_segments": [
                                 {
                                     "id": "segment123",
-                                    "leader": {"name": "John Doe"},
+                                    "leader": {
+                                        "id": "leader-123",
+                                        "name": "John Doe",
+                                        "subject_type": "person",
+                                        "subject_subtype": "ranger"
+                                    },
                                     "patrol_type": "boat_patrol",
                                     "start_location": {"latitude": 1.234, "longitude": 5.678},
                                     "end_location": null,
@@ -88,11 +93,11 @@ func TestPatrols(t *testing.T) {
 				if segment.ID != "segment123" {
 					t.Errorf("Expected segment ID 'segment123', got '%s'", segment.ID)
 				}
-				if segment.Leader == nil {
-					t.Fatal("Expected non-nil leader")
-				}
 				if segment.Leader.Name != "John Doe" {
 					t.Errorf("Expected leader name 'John Doe', got '%s'", segment.Leader.Name)
+				}
+				if segment.Leader.ID != "leader-123" {
+					t.Errorf("Expected leader ID 'leader-123', got '%s'", segment.Leader.ID)
 				}
 				// Open patrol should not have end location or end time
 				if segment.EndLocation != nil {
@@ -119,7 +124,12 @@ func TestPatrols(t *testing.T) {
                             "patrol_segments": [
                                 {
                                     "id": "segment456",
-                                    "leader": {"name": "Jane Smith"},
+                                    "leader": {
+                                        "id": "leader-456",
+                                        "name": "Jane Smith",
+                                        "subject_type": "person",
+                                        "subject_subtype": "ranger"
+                                    },
                                     "patrol_type": "foot_patrol",
                                     "start_location": {"latitude": 2.345, "longitude": 6.789},
                                     "end_location": {"latitude": 2.355, "longitude": 6.799},
@@ -200,6 +210,12 @@ func TestPatrols(t *testing.T) {
                             "patrol_segments": [
                                 {
                                     "id": "segment789",
+                                    "leader": {
+                                        "id": "leader-789",
+                                        "name": "Active Leader",
+                                        "subject_type": "person",
+                                        "subject_subtype": "ranger"
+                                    },
                                     "patrol_type": "vehicle_patrol",
                                     "start_location": {"latitude": 3.456, "longitude": 7.890},
                                     "end_location": null,
@@ -358,5 +374,410 @@ func TestDateRangeFilter(t *testing.T) {
 	_, err := client.Patrols(7, "")
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
+	}
+}
+
+func TestPatrolByID(t *testing.T) {
+	tests := []struct {
+		name            string
+		patrolID        string
+		mockResponse    string
+		expectedError   bool
+		validateResult  func(*testing.T, *PatrolByIDResponse)
+		validateRequest func(*testing.T, *http.Request)
+	}{
+		{
+			name:     "successful response",
+			patrolID: "test-patrol-123",
+			mockResponse: `{
+                "data": {
+                    "id": "test-patrol-123",
+                    "serial_number": 4273,
+                    "state": "done",
+                    "title": "Test Patrol Track",
+                    "patrol_segments": [
+                        {
+                            "id": "segment-123",
+                            "leader": {
+                                "id": "leader-456",
+                                "name": "John Tracker",
+                                "subject_type": "person",
+                                "subject_subtype": "ranger"
+                            },
+                            "patrol_type": "bicycle-patrol",
+                            "start_location": {
+                                "latitude": 47.5728823,
+                                "longitude": -121.9877074
+                            },
+                            "end_location": {
+                                "latitude": 47.5778543,
+                                "longitude": -121.9773813
+                            },
+                            "time_range": {
+                                "start_time": "2025-08-16T22:08:03Z",
+                                "end_time": "2025-08-16T22:18:08Z"
+                            }
+                        }
+                    ]
+                },
+                "status": {
+                    "code": 200,
+                    "message": "OK"
+                }
+            }`,
+			expectedError: false,
+			validateRequest: func(t *testing.T, r *http.Request) {
+				expectedPath := "/api/v1.0/activity/patrols/test-patrol-123"
+				if r.URL.Path != expectedPath {
+					t.Errorf("Expected path %s, got %s", expectedPath, r.URL.Path)
+				}
+				if r.Method != http.MethodGet {
+					t.Errorf("Expected GET request, got %s", r.Method)
+				}
+			},
+			validateResult: func(t *testing.T, response *PatrolByIDResponse) {
+				if response == nil {
+					t.Fatal("Expected non-nil response")
+				}
+				if response.Data.ID != "test-patrol-123" {
+					t.Errorf("Expected ID 'test-patrol-123', got '%s'", response.Data.ID)
+				}
+				if response.Data.SerialNumber != 4273 {
+					t.Errorf("Expected serial number 4273, got %d", response.Data.SerialNumber)
+				}
+				if response.Data.State != "done" {
+					t.Errorf("Expected state 'done', got '%s'", response.Data.State)
+				}
+				if response.Data.Title != "Test Patrol Track" {
+					t.Errorf("Expected title 'Test Patrol Track', got '%s'", response.Data.Title)
+				}
+				if len(response.Data.PatrolSegments) != 1 {
+					t.Fatalf("Expected 1 patrol segment, got %d", len(response.Data.PatrolSegments))
+				}
+				
+				segment := response.Data.PatrolSegments[0]
+				if segment.ID != "segment-123" {
+					t.Errorf("Expected segment ID 'segment-123', got '%s'", segment.ID)
+				}
+				if segment.Leader.ID != "leader-456" {
+					t.Errorf("Expected leader ID 'leader-456', got '%s'", segment.Leader.ID)
+				}
+				if segment.Leader.Name != "John Tracker" {
+					t.Errorf("Expected leader name 'John Tracker', got '%s'", segment.Leader.Name)
+				}
+				if segment.Leader.SubjectType != "person" {
+					t.Errorf("Expected leader subject type 'person', got '%s'", segment.Leader.SubjectType)
+				}
+				if segment.Leader.SubjectSubtype != "ranger" {
+					t.Errorf("Expected leader subject subtype 'ranger', got '%s'", segment.Leader.SubjectSubtype)
+				}
+				if segment.TimeRange.StartTime == nil {
+					t.Fatal("Expected non-nil start time")
+				}
+				if *segment.TimeRange.StartTime != "2025-08-16T22:08:03Z" {
+					t.Errorf("Expected start time '2025-08-16T22:08:03Z', got '%s'", *segment.TimeRange.StartTime)
+				}
+				if segment.TimeRange.EndTime == nil {
+					t.Fatal("Expected non-nil end time for done patrol")
+				}
+				if *segment.TimeRange.EndTime != "2025-08-16T22:18:08Z" {
+					t.Errorf("Expected end time '2025-08-16T22:18:08Z', got '%s'", *segment.TimeRange.EndTime)
+				}
+			},
+		},
+		{
+			name:     "active patrol without end time",
+			patrolID: "active-patrol-789",
+			mockResponse: `{
+                "data": {
+                    "id": "active-patrol-789",
+                    "serial_number": 4274,
+                    "state": "active",
+                    "title": "Active Patrol",
+                    "patrol_segments": [
+                        {
+                            "id": "segment-789",
+                            "leader": {
+                                "id": "leader-789",
+                                "name": "Jane Ranger",
+                                "subject_type": "person",
+                                "subject_subtype": "ranger"
+                            },
+                            "patrol_type": "foot-patrol",
+                            "start_location": {
+                                "latitude": 47.5728823,
+                                "longitude": -121.9877074
+                            },
+                            "end_location": null,
+                            "time_range": {
+                                "start_time": "2025-08-16T22:08:03Z",
+                                "end_time": null
+                            }
+                        }
+                    ]
+                },
+                "status": {
+                    "code": 200,
+                    "message": "OK"
+                }
+            }`,
+			expectedError: false,
+			validateRequest: func(t *testing.T, r *http.Request) {
+				expectedPath := "/api/v1.0/activity/patrols/active-patrol-789"
+				if r.URL.Path != expectedPath {
+					t.Errorf("Expected path %s, got %s", expectedPath, r.URL.Path)
+				}
+			},
+			validateResult: func(t *testing.T, response *PatrolByIDResponse) {
+				if response == nil {
+					t.Fatal("Expected non-nil response")
+				}
+				if response.Data.State != "active" {
+					t.Errorf("Expected state 'active', got '%s'", response.Data.State)
+				}
+				segment := response.Data.PatrolSegments[0]
+				if segment.EndLocation != nil {
+					t.Error("Expected nil end location for active patrol")
+				}
+				if segment.TimeRange.EndTime != nil {
+					t.Error("Expected nil end time for active patrol")
+				}
+			},
+		},
+		{
+			name:          "error response",
+			patrolID:      "nonexistent-patrol",
+			mockResponse:  `{"status": {"code": 404, "message": "Not Found"}}`,
+			expectedError: true,
+			validateRequest: func(t *testing.T, r *http.Request) {
+				expectedPath := "/api/v1.0/activity/patrols/nonexistent-patrol"
+				if r.URL.Path != expectedPath {
+					t.Errorf("Expected path %s, got %s", expectedPath, r.URL.Path)
+				}
+			},
+			validateResult: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if tt.validateRequest != nil {
+					tt.validateRequest(t, r)
+				}
+
+				w.Header().Set("Content-Type", "application/json")
+				if strings.Contains(tt.mockResponse, `"code": 404`) {
+					w.WriteHeader(http.StatusNotFound)
+				}
+				if _, err := w.Write([]byte(tt.mockResponse)); err != nil {
+					t.Errorf("Failed to write response: %v", err)
+				}
+			}))
+			defer server.Close()
+
+			client := ERClient("test", "test-token", server.URL)
+			response, err := client.PatrolByID(tt.patrolID)
+
+			if tt.expectedError {
+				if err == nil {
+					t.Error("Expected error, got nil")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("Unexpected error: %v", err)
+				return
+			}
+
+			if tt.validateResult != nil {
+				tt.validateResult(t, response)
+			}
+		})
+	}
+}
+
+func TestPatrolTracks(t *testing.T) {
+	tests := []struct {
+		name            string
+		subjectID       string
+		since           string
+		until           string
+		mockResponse    string
+		expectedError   bool
+		validateResult  func(*testing.T, *TracksResponse)
+		validateRequest func(*testing.T, *http.Request)
+	}{
+		{
+			name:      "successful tracks response",
+			subjectID: "leader-456",
+			since:     "2025-08-16T22:08:03Z",
+			until:     "2025-08-16T22:18:08Z",
+			mockResponse: `{
+                "data": {
+                    "type": "FeatureCollection",
+                    "features": [
+                        {
+                            "type": "Feature",
+                            "geometry": {
+                                "type": "LineString",
+                                "coordinates": [
+                                    [-121.9877074, 47.5728823],
+                                    [-121.9825436, 47.5753245],
+                                    [-121.9773813, 47.5778543]
+                                ]
+                            },
+                            "properties": {
+                                "id": "leader-456",
+                                "title": "John Tracker",
+                                "subject_type": "person",
+                                "subject_subtype": "ranger",
+                                "coordinateProperties": {
+                                    "times": [
+                                        "2025-08-16T22:08:03Z",
+                                        "2025-08-16T22:13:05Z",
+                                        "2025-08-16T22:18:08Z"
+                                    ]
+                                }
+                            }
+                        }
+                    ]
+                },
+                "status": {
+                    "code": 200,
+                    "message": "OK"
+                }
+            }`,
+			expectedError: false,
+			validateRequest: func(t *testing.T, r *http.Request) {
+				expectedPath := "/api/v1.0/subject/leader-456/tracks"
+				if r.URL.Path != expectedPath {
+					t.Errorf("Expected path %s, got %s", expectedPath, r.URL.Path)
+				}
+				query := r.URL.Query()
+				if query.Get("since") != "2025-08-16T22:08:03Z" {
+					t.Errorf("Expected since parameter '2025-08-16T22:08:03Z', got '%s'", query.Get("since"))
+				}
+				if query.Get("until") != "2025-08-16T22:18:08Z" {
+					t.Errorf("Expected until parameter '2025-08-16T22:18:08Z', got '%s'", query.Get("until"))
+				}
+			},
+			validateResult: func(t *testing.T, response *TracksResponse) {
+				if response == nil {
+					t.Fatal("Expected non-nil response")
+				}
+				if response.Data.Type != "FeatureCollection" {
+					t.Errorf("Expected type 'FeatureCollection', got '%s'", response.Data.Type)
+				}
+				if len(response.Data.Features) != 1 {
+					t.Fatalf("Expected 1 feature, got %d", len(response.Data.Features))
+				}
+				
+				feature := response.Data.Features[0]
+				if feature.Type != "Feature" {
+					t.Errorf("Expected feature type 'Feature', got '%s'", feature.Type)
+				}
+				if feature.Geometry.Type != "LineString" {
+					t.Errorf("Expected geometry type 'LineString', got '%s'", feature.Geometry.Type)
+				}
+				if len(feature.Geometry.Coordinates) != 3 {
+					t.Errorf("Expected 3 coordinate pairs, got %d", len(feature.Geometry.Coordinates))
+				}
+				if feature.Properties.ID != "leader-456" {
+					t.Errorf("Expected properties ID 'leader-456', got '%s'", feature.Properties.ID)
+				}
+				if feature.Properties.Title != "John Tracker" {
+					t.Errorf("Expected properties title 'John Tracker', got '%s'", feature.Properties.Title)
+				}
+				if len(feature.Properties.CoordinateProperties.Times) != 3 {
+					t.Errorf("Expected 3 timestamps, got %d", len(feature.Properties.CoordinateProperties.Times))
+				}
+			},
+		},
+		{
+			name:      "empty tracks response",
+			subjectID: "leader-999",
+			since:     "2025-08-16T22:08:03Z",
+			until:     "2025-08-16T22:18:08Z",
+			mockResponse: `{
+                "data": {
+                    "type": "FeatureCollection",
+                    "features": []
+                },
+                "status": {
+                    "code": 200,
+                    "message": "OK"
+                }
+            }`,
+			expectedError: false,
+			validateRequest: func(t *testing.T, r *http.Request) {
+				expectedPath := "/api/v1.0/subject/leader-999/tracks"
+				if r.URL.Path != expectedPath {
+					t.Errorf("Expected path %s, got %s", expectedPath, r.URL.Path)
+				}
+			},
+			validateResult: func(t *testing.T, response *TracksResponse) {
+				if response == nil {
+					t.Fatal("Expected non-nil response")
+				}
+				if len(response.Data.Features) != 0 {
+					t.Errorf("Expected 0 features, got %d", len(response.Data.Features))
+				}
+			},
+		},
+		{
+			name:          "error response",
+			subjectID:     "invalid-subject",
+			since:         "2025-08-16T22:08:03Z",
+			until:         "2025-08-16T22:18:08Z",
+			mockResponse:  `{"status": {"code": 404, "message": "Subject not found"}}`,
+			expectedError: true,
+			validateRequest: func(t *testing.T, r *http.Request) {
+				expectedPath := "/api/v1.0/subject/invalid-subject/tracks"
+				if r.URL.Path != expectedPath {
+					t.Errorf("Expected path %s, got %s", expectedPath, r.URL.Path)
+				}
+			},
+			validateResult: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if tt.validateRequest != nil {
+					tt.validateRequest(t, r)
+				}
+
+				w.Header().Set("Content-Type", "application/json")
+				if strings.Contains(tt.mockResponse, `"code": 404`) {
+					w.WriteHeader(http.StatusNotFound)
+				}
+				if _, err := w.Write([]byte(tt.mockResponse)); err != nil {
+					t.Errorf("Failed to write response: %v", err)
+				}
+			}))
+			defer server.Close()
+
+			client := ERClient("test", "test-token", server.URL)
+			response, err := client.PatrolTracks(tt.subjectID, tt.since, tt.until)
+
+			if tt.expectedError {
+				if err == nil {
+					t.Error("Expected error, got nil")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("Unexpected error: %v", err)
+				return
+			}
+
+			if tt.validateResult != nil {
+				tt.validateResult(t, response)
+			}
+		})
 	}
 }

--- a/cmd/patrols.go
+++ b/cmd/patrols.go
@@ -102,10 +102,7 @@ func formatPatrolData(patrol *api.Patrol) []string {
 		segment := patrol.PatrolSegments[0]
 		segmentID = segment.ID
 
-		if segment.Leader != nil {
-			l := segment.Leader
-			leader = l.Name
-		}
+		leader = segment.Leader.Name
 
 		if segment.StartLocation != nil {
 			startLocation = fmt.Sprintf("%.6f, %.6f",

--- a/cmd/patrols.go
+++ b/cmd/patrols.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/doneill/er-cli/api"
 	"github.com/doneill/er-cli/config"
+	"github.com/doneill/er-cli/utils"
 	"github.com/olekukonko/tablewriter"
 	"github.com/spf13/cobra"
 )
@@ -15,6 +16,7 @@ import (
 var (
 	days   int
 	status string
+	track  string
 )
 
 var validStatuses = map[string]bool{
@@ -46,7 +48,11 @@ var patrolsCmd = &cobra.Command{
 		return nil
 	},
 	Run: func(cmd *cobra.Command, args []string) {
-		patrols()
+		if track != "" {
+			patrolTrack()
+		} else {
+			patrols()
+		}
 	},
 }
 
@@ -165,6 +171,65 @@ func configurePatrolsTable() *tablewriter.Table {
 	return table
 }
 
+func patrolTrack() {
+	client := api.ERClient(config.Sitename(), config.Token())
+	handlePatrolTrack(client)
+}
+
+func handlePatrolTrack(client *api.Client) {
+	// First get the patrol details
+	patrolResponse, err := client.PatrolByID(track)
+	if err != nil {
+		log.Fatalf("Error getting patrol: %v", err)
+	}
+
+	if len(patrolResponse.Data.PatrolSegments) == 0 {
+		fmt.Println("No patrol segments found for this patrol")
+		return
+	}
+
+	// Get the first segment
+	segment := patrolResponse.Data.PatrolSegments[0]
+	
+	if segment.TimeRange.StartTime == nil {
+		fmt.Println("No start time found for patrol segment")
+		return
+	}
+
+	// Determine end time - use current time if patrol is active (no end time)
+	endTime := ""
+	if segment.TimeRange.EndTime != nil {
+		endTime = *segment.TimeRange.EndTime
+	} else {
+		endTime = time.Now().UTC().Format("2006-01-02T15:04:05Z")
+		fmt.Printf("Patrol is active, using current time as end: %s\n", endTime)
+	}
+
+	// Get tracks for the patrol leader
+	tracksResponse, err := client.PatrolTracks(segment.Leader.ID, *segment.TimeRange.StartTime, endTime)
+	if err != nil {
+		log.Fatalf("Error getting patrol tracks: %v", err)
+	}
+
+	if len(tracksResponse.Data.Features) == 0 {
+		fmt.Println("No tracks found for this patrol")
+		return
+	}
+
+	// Export to GeoJSON file
+	filename := fmt.Sprintf("patrol_%d_tracks.geojson", patrolResponse.Data.SerialNumber)
+	if err := utils.ExportToFile(tracksResponse.Data, filename); err != nil {
+		log.Fatalf("Error exporting GeoJSON: %v", err)
+	}
+
+	fmt.Printf("Patrol tracks exported to %s\n", filename)
+	fmt.Printf("Patrol: %s (Serial: %d)\n", patrolResponse.Data.Title, patrolResponse.Data.SerialNumber)
+	fmt.Printf("Leader: %s\n", segment.Leader.Name)
+	fmt.Printf("Start: %s\n", formatTime(segment.TimeRange.StartTime))
+	fmt.Printf("End: %s\n", formatTime(segment.TimeRange.EndTime))
+	fmt.Printf("Tracks: %d features\n", len(tracksResponse.Data.Features))
+}
+
 // ----------------------------------------------
 // initialize
 // ----------------------------------------------
@@ -173,4 +238,5 @@ func init() {
 	rootCmd.AddCommand(patrolsCmd)
 	patrolsCmd.Flags().IntVarP(&days, "days", "d", 7, "Number of days to fetch patrols for")
 	patrolsCmd.Flags().StringVarP(&status, "status", "s", "", "Patrol status (active, done, or cancelled)")
+	patrolsCmd.Flags().StringVarP(&track, "track", "t", "", "Get tracks for a specific patrol ID")
 }


### PR DESCRIPTION
**Proposed Changes**
- Add `PatrolTracks` function
- Add `PatrolByID` function
  - Add respective type structs
- Add new patrol `--tracks` flag
  - Flag take patrol id as `string` value and passes to `PatrolByID` function
  - Generates geojson file using serial number in naming
- Update tests

**Expectation:**
Usage:

  - List patrols: `erpatrols --days 7`
  - Get patrol tracks: `er patrols --track {patrol id}`

Tests Added:

- TestPatrolByID - Tests patrol by ID functionality with:
    - Successful response with complete patrol data
    - Active patrol without end time/location
    - Error handling for non-existent patrols
- TestPatrolTracks - Tests patrol tracks functionality with:
    - Successful tracks response with GeoJSON LineString
    - Empty tracks response
    - Error handling for invalid subjects