### PR TITLE
Refactor pending sync query

### DIFF
--- a/data/persistent_store.go
+++ b/data/persistent_store.go
@@ -57,7 +57,7 @@ func SelectUserProfileById(id int) User_Profile {
 
 func SelectPendingSyncEvents() []Event {
 	var events []Event
-	db.Where("is_draft = 0").Where(db.Where("remote_id IS NULL").Or("remote_id = ?", "")).Find(&events)
+	db.Where("is_draft = 0").Where(db.Where("serial_number IS NULL").Or("serial_number = ?", "")).Find(&events)
 	return events
 }
 


### PR DESCRIPTION
**Proposed Changes**
- Refactored `SelectPendingSyncEvents` `Where` clause to `serial_number`

**Expectation:**
- Run `er open {db} -e` against a database with pending sync events
- Verify results are accurate